### PR TITLE
데몬 프로세스로의 변경 및 갖가지 수정

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,10 +1,13 @@
 import openpyxl
 import os
+import platform
 from multiprocessing import Process
 import json
 
 process_number= []
 startrow= 0
+
+platform_name = platform.system()
 
 def load_json_file(filename: str) -> dict:
     with open(filename, encoding='utf-8') as file_stream:
@@ -17,7 +20,10 @@ def fix_json_file(filename: str, filedata: dict):
 
 def make_json_file(filename: str):
     try:
-        os.system('rm -rf ./log.json')
+        if platform_name == "Windows":
+            os.system('del log.json')
+        else:
+            os.system('rm -rf ./log.json')
     except:
         with open(filename, 'w', encoding='utf-8') as _:
             pass
@@ -65,7 +71,7 @@ except :
 
 
 def run(url, id, pw):
-    os.system(f'youtube-dl --username {id} --password {pw} {url}')
+    os.system(f'youtube-dl --username \"{id}\" --password \"{pw}\" \"{url}\"')
 
 def job(processnum: int):
     global list
@@ -83,12 +89,14 @@ def job(processnum: int):
 
             fix_json_file('log.json', json_data)
 
-        if urlid == 'None':
+        if urlid.isdigit():
+            url = f'https://vlive.tv/video/{urlid}'
+            print(f"{url} {row}")
+            run(url, id, pw)
+        elif urlid == 'None':
             break
-        url = f'https://vlive.tv/video/{urlid}'
-
-        print(f"{url} {row}")
-        run(url, id, pw)
+        else:
+            pass
 
         process_number[processnum] = process_number[processnum] + totprocess
 
@@ -98,6 +106,7 @@ if __name__ == "__main__":
 
     for i in range(totprocess):
         proc= Process(target= job, args= (i,),)
+        proc.daemon = True
         print(f"========Process {i} is running========")
         proc.start()
         procs.append(proc)


### PR DESCRIPTION
make_json_file에서 Windows의 경우 rm 명령어가 존재하지 않아서 OS에 따라 다른 명령어가 실행되도록 하였구요.
youtube-dl을 실행하는 구문에선 아이디, 비밀번호에 특수문자가 존재하는 경우 명령어가 escape될 수 있는 문제가 있어, 쌍따옴표를 붙이는 것으로 해당 문제를 수정하였습니다.
그리고 urlid 값이 숫자면 명령을 그대로 처리하되, 문자열 등 다른 형식인 경우(예를 들면, 'Vapp Number'와 같은 경우..) 명령을 실행하지 않고 다음 값으로 넘어가도록 수정하였습니다.
또한 윈도우에서는 문제가 없었으나 테스트한 Ubuntu 20.04 LTS 등 리눅스 배포판에서 브이앱 영상을 다운로드하는 과정 중에 Ctrl+C로 메인 프로세스를 종료해도, 명령이 계속 실행되는 문제가 있어 데몬 프로세스로 변경하여 해당 문제를 해결하였습니다.